### PR TITLE
Fix regional spelling

### DIFF
--- a/public/javascripts/controllers/crash.js
+++ b/public/javascripts/controllers/crash.js
@@ -9,7 +9,7 @@ import renderGameOver from '../views/game_over.js'
 
 class Crash extends Lose {
   render ({ element }) {
-    renderGameOver({ element, message: 'Totalled' })
+    renderGameOver({ element, message: 'Totaled' })
   }
 }
 


### PR DESCRIPTION
The correctness depends on if the game takes place in a certain region.

`Totalled` is correct for British/Canadian/Australian
`Totaled` would be correct for American English

I think the original game takes place throughout Europe, however, this version has gives some Californian vibes